### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,6 @@ spell check:<br/>
 ![spell-check](https://github.com/dongyuwei/hallelujahIM/blob/master/snapshots/check4.png)
 ![spell-check](https://github.com/dongyuwei/hallelujahIM/blob/master/snapshots/check5.png)
 
-##Paid Support
+## Paid Support
 
 If functional you need is missing but you're ready to pay for it, feel free to contact me. If not, create an issue anyway, I'll take a look as soon as I can.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
