### PR TITLE
fix: frequency value overflow

### DIFF
--- a/Tests/TestConversionEngine.mm
+++ b/Tests/TestConversionEngine.mm
@@ -40,6 +40,12 @@
         isEqualToString:@"test;testing;tests;tested;testimonials;testimony;testament;tester;testified;testers"]);
 }
 
+- (void)testSortWordsByFrequencyFromLargeNumberOfCandidates {
+    NSArray *words = [self.engine wordsStartsWith:@"in"];
+    NSArray *sorted = [self.engine sortWordsByFrequency:words];
+    XCTAssertTrue([[sorted objectAtIndex:0] isEqualToString:@"in"]);
+}
+
 - (void)testPhonexEncode {
     JSValue *phonexFunc = self.engine.phonexEncoder;
     XCTAssertTrue([[[phonexFunc callWithArguments:@[ @"test" ]] toString] isEqualToString:@"T23"]);

--- a/src/ConversionEngine.mm
+++ b/src/ConversionEngine.mm
@@ -87,7 +87,7 @@ marisa::Trie trie;
     NSArray *sorted = [filtered sortedArrayUsingComparator:^NSComparisonResult(id word1, id word2) {
         NSDictionary *dict1 = words[word1];
         NSDictionary *dict2 = words[word2];
-        int n = [dict1[@"frequency"] intValue] - [dict2[@"frequency"] intValue];
+        int64_t n = [dict1[@"frequency"] longLongValue] - [dict2[@"frequency"] longLongValue];
         if (n > 0) {
             return (NSComparisonResult)NSOrderedAscending;
         }


### PR DESCRIPTION
## Description
Most frequent words are ranked at last positions, like `in`, `the`, etc.
## Bug
Int value overflow happened while using `int` to store the value of `[dict1[@"frequency"] intValue] - [dict2[@"frequency"] intValue]`.

For example, when typing `in`, there are many words (3K and more) starting with `in*`. While comparing the word **'in'** with other words which have much lower frequency, the result might be a greater value than the capacity of `int n`, because the frequency of the word **'in'** is `8469404971`, which is quite large. This caused the word **'in'** be ranked in the tail of the result list. Actually, the word **'in'** should be the first one in the list.