### PR TITLE
Fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,4 +232,4 @@ pinyin in, English out: <br/>
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dongyuwei/hallelujahIM&type=Date)](https://star-history.com/#dongyuwei/hallelujahIM&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dongyuwei/hallelujahIM&type=Date)](https://star-history.dera.page/#dongyuwei/hallelujahIM&Date)


### PR DESCRIPTION
The Star History chart on this repository is broken: GitHub's stargazer API restrictions prevent the image from loading, so readers no longer see the project's growth.

This change points the chart at a working alternative that requires no API token, restoring the chart for anyone viewing the README.