### PR TITLE
fix: guard English candidate digit selection

### DIFF
--- a/src/InputController.mm
+++ b/src/InputController.mm
@@ -486,13 +486,13 @@ static BOOL ContainsChineseCharacter(NSString *text) {
 
             if (keyCode == KEY_ARROW_DOWN) {
                 [sharedCandidates moveDown:self];
-                _currentCandidateIndex++;
+                _currentCandidateIndex = MIN(_currentCandidateIndex + 1, (NSInteger)_candidates.count);
                 return NO;
             }
 
             if (keyCode == KEY_ARROW_UP) {
                 [sharedCandidates moveUp:self];
-                _currentCandidateIndex--;
+                _currentCandidateIndex = MAX(_currentCandidateIndex - 1, 1);
                 return NO;
             }
         }
@@ -505,15 +505,20 @@ static BOOL ContainsChineseCharacter(NSString *text) {
             }
 
             if (isCandidatesVisible) { // use 1~9 digital numbers as selection keys
-                int pressedNumber = characters.intValue;
-                NSString *candidate;
-                int pageSize = 9;
-                if (_currentCandidateIndex <= pageSize) {
-                    candidate = _candidates[pressedNumber - 1];
-                } else {
-                    candidate = _candidates[pageSize * (_currentCandidateIndex / pageSize - 1) + (_currentCandidateIndex % pageSize) +
-                                            pressedNumber - 1];
+                NSInteger pressedNumber = characters.integerValue;
+                NSInteger pageSize = 9;
+                if (pressedNumber < 1 || pressedNumber > pageSize || _candidates.count == 0) {
+                    return NO;
                 }
+
+                NSInteger currentIndex = MIN(MAX(_currentCandidateIndex, 1), (NSInteger)_candidates.count);
+                NSInteger pageStart = ((currentIndex - 1) / pageSize) * pageSize;
+                NSInteger candidateIndex = pageStart + pressedNumber - 1;
+                if (candidateIndex < 0 || candidateIndex >= (NSInteger)_candidates.count) {
+                    return NO;
+                }
+
+                NSString *candidate = _candidates[candidateIndex];
                 [self cancelComposition];
                 [self setComposedBuffer:candidate];
                 [self setOriginalBuffer:candidate];


### PR DESCRIPTION
## Summary

- reject digit shortcuts outside `1...9` before indexing the candidate array
- validate the computed page-relative candidate index before selection
- calculate page starts from the current 1-based candidate position
- clamp arrow-key tracking to the available candidate range

This prevents `0` and unpopulated candidate slots from causing an out-of-bounds exception, and fixes digit selection after scrolling beyond the first nine candidates.

## Validation

- `sh format-code.sh`
- Objective-C++ syntax check with Apple Clang
- Clang static analyzer on `InputController.mm`
- boundary cases checked for `0`, first/second/partial pages, and unavailable rows